### PR TITLE
Fix for laravel 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "guzzlehttp/guzzle": "^6.3",
+        "guzzlehttp/guzzle": "^6.3|^7.0",
         "illuminate/notifications": "^5.5 || ^6.0 || ^7.0 || ^8.0",
         "illuminate/support": "^5.5 || ^6.0 || ^7.0 || ^8.0"
     },


### PR DESCRIPTION
Laravel 8 also requires Guzzle 7.